### PR TITLE
Feature/bundelize gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-.DS_Store
 pkg/*
+*.gem
+.bundle
+.DS_Store
 spec/config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/*
 .bundle
 .DS_Store
 spec/config.yml
+rdoc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in testgem.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,27 @@
+PATH
+  remote: .
+  specs:
+    massive_record (0.0.1)
+      thrift (>= 0.5.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.2)
+    rspec (2.1.0)
+      rspec-core (~> 2.1.0)
+      rspec-expectations (~> 2.1.0)
+      rspec-mocks (~> 2.1.0)
+    rspec-core (2.1.0)
+    rspec-expectations (2.1.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.1.0)
+    thrift (0.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  massive_record!
+  rspec (>= 2.1.0)
+  thrift (>= 0.5.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,15 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
+
+require 'rake/rdoctask'
+Rake::RDocTask.new do |rdoc|
+  version = File.exist?('VERSION') ? File.read('VERSION') : ""
+
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title = "devise_facebook_open_graph #{version}"
+  rdoc.rdoc_files.include('README*')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,2 @@
-require 'rubygems'
-require 'rake'
-require 'echoe'
-
-Echoe.new('massive_record', '0.0.1') do |p|
-  p.description    = "HBase Ruby client API" 
-  p.url            = "http://github.com/CompanyBook/massive_record"
-  p.author         = "Companybook"
-  p.email          = "geeks@companybook.no"
-  p.ignore_pattern = ["tmp/*", "script/*"]
-  p.development_dependencies = []
-end
+require 'bundler'
+Bundler::GemHelper.install_tasks

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
+$:.push File.expand_path("../lib", __FILE__)
 require 'bundler'
+require "massive_record/version"
+
 Bundler::GemHelper.install_tasks
 
 require "rspec/core/rake_task"
@@ -6,10 +9,8 @@ RSpec::Core::RakeTask.new(:spec)
 
 require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
   rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "devise_facebook_open_graph #{version}"
+  rdoc.title = "MassiveRecord #{MassiveRecord::VERSION}"
   rdoc.rdoc_files.include('README*')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end

--- a/lib/massive_record/version.rb
+++ b/lib/massive_record/version.rb
@@ -1,0 +1,3 @@
+module MassiveRecord
+  VERSION = "0.0.1"
+end

--- a/massive_record.gemspec
+++ b/massive_record.gemspec
@@ -1,30 +1,21 @@
 # -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "massive_record/version"
 
 Gem::Specification.new do |s|
-  s.name = %q{massive_record}
-  s.version = "0.0.1"
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Companybook"]
-  s.date = %q{2010-11-25}
+  s.name        = "massive_record"
+  s.version     = MassiveRecord::VERSION
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = ["Companybook"]
+  s.email       = %q{geeks@companybook.no}
+  s.homepage    = %q{http://github.com/CompanyBook/massive_record}
+  s.summary     = %q{HBase Ruby client API}
   s.description = %q{HBase Ruby client API}
-  s.email = %q{geeks@companybook.no}
-  s.extra_rdoc_files = ["README.md", "lib/massive_record.rb", "lib/massive_record/base.rb", "lib/massive_record/cell.rb", "lib/massive_record/column_families_collection.rb", "lib/massive_record/column_family.rb", "lib/massive_record/connection.rb", "lib/massive_record/migration.rb", "lib/massive_record/row.rb", "lib/massive_record/scanner.rb", "lib/massive_record/table.rb", "lib/massive_record/tables_collection.rb", "lib/massive_record/thrift/hbase.rb", "lib/massive_record/thrift/hbase_constants.rb", "lib/massive_record/thrift/hbase_types.rb"]
-  s.files = ["Manifest", "README.md", "Rakefile", "autotest/discover.rb", "lib/massive_record.rb", "lib/massive_record/base.rb", "lib/massive_record/cell.rb", "lib/massive_record/column_families_collection.rb", "lib/massive_record/column_family.rb", "lib/massive_record/connection.rb", "lib/massive_record/migration.rb", "lib/massive_record/row.rb", "lib/massive_record/scanner.rb", "lib/massive_record/table.rb", "lib/massive_record/tables_collection.rb", "lib/massive_record/thrift/hbase.rb", "lib/massive_record/thrift/hbase_constants.rb", "lib/massive_record/thrift/hbase_types.rb", "massive_record.gemspec", "spec/README.md", "spec/config.yml.example", "spec/connection_spec.rb", "spec/spec_helper.rb", "spec/table_spec.rb"]
-  s.homepage = %q{http://github.com/CompanyBook/massive_record}
-  s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Massive_record", "--main", "README.md"]
+
+  s.rubyforge_project = "massive_record"
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.rubyforge_project = %q{massive_record}
-  s.rubygems_version = %q{1.3.7}
-  s.summary = %q{HBase Ruby client API}
-
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-    else
-    end
-  else
-  end
 end

--- a/massive_record.gemspec
+++ b/massive_record.gemspec
@@ -3,16 +3,21 @@ $:.push File.expand_path("../lib", __FILE__)
 require "massive_record/version"
 
 Gem::Specification.new do |s|
-  s.name        = "massive_record"
-  s.version     = MassiveRecord::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Companybook"]
-  s.email       = %q{geeks@companybook.no}
-  s.homepage    = %q{http://github.com/CompanyBook/massive_record}
-  s.summary     = %q{HBase Ruby client API}
-  s.description = %q{HBase Ruby client API}
-
+  s.name              = "massive_record"
+  s.version           = MassiveRecord::VERSION
+  s.platform          = Gem::Platform::RUBY
+  s.authors           = ["Companybook"]
+  s.email             = %q{geeks@companybook.no}
+  s.homepage          = %q{http://github.com/CompanyBook/massive_record}
+  s.summary           = %q{HBase Ruby client API}
+  s.description       = %q{HBase Ruby client API}
   s.rubyforge_project = "massive_record"
+
+
+  s.add_dependency "thrift", ">= 0.5.0"
+
+  s.add_development_dependency "rspec", ">= 2.1.0"
+
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'spec_helper'
 
 describe MassiveRecord::Connection do
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,12 @@
-SPEC_DIR = File.dirname(__FILE__) unless defined? SPEC_DIR
-lib_path = File.expand_path("#{SPEC_DIR}/../lib")
-$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
-
-require 'massive_record'
+require 'rubygems'
+require 'bundler'
 require 'yaml'
 
+Bundler.require :default, :development
+
+SPEC_DIR = File.dirname(__FILE__) unless defined? SPEC_DIR
 MR_CONFIG = YAML.load_file(File.join(SPEC_DIR, 'config.yml')) unless defined? MR_CONFIG
+
+Rspec.configure do |c|
+
+end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'spec_helper'
 
 describe MassiveRecord::Table do
   


### PR DESCRIPTION
- Removed Echoe.
- Took use of Bundler.

With this set of changes the gem will take care of it's own dependency needs, like require thrift, so projects using this them doesn't need to add thrift manually in their Gemfile.

Haven't actually gotten a chance to run rspec tests, as the server is down, but I do guess it should work. At least they seems to be running doing a `rspec spec/` or `rake spec`.

Reference:
https://github.com/radar/guides/blob/master/gem-development.md
