### PR TITLE
Fixed issues when moving to rails 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    massive_record (0.2.2.rc3)
+    massive_record (0.2.2.rc4)
       activemodel (= 3.1.1)
       activesupport (= 3.1.1)
       thrift (= 0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,36 @@ PATH
   remote: .
   specs:
     massive_record (0.2.2.rc3)
-      activemodel (~> 3.0.7)
-      activesupport (~> 3.0.7)
+      activemodel (= 3.1.1)
+      activesupport (= 3.1.1)
       thrift (= 0.6.0)
       tzinfo
+      yajl-ruby
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.10)
-      activesupport (= 3.0.10)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activesupport (3.0.10)
-    builder (2.1.2)
+    activemodel (3.1.1)
+      activesupport (= 3.1.1)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activesupport (3.1.1)
+      multi_json (~> 1.0)
+    builder (3.0.0)
     diff-lcs (1.1.3)
-    i18n (0.5.0)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
+    i18n (0.6.0)
+    multi_json (1.0.4)
+    rspec (2.7.0)
+      rspec-core (~> 2.7.0)
+      rspec-expectations (~> 2.7.0)
+      rspec-mocks (~> 2.7.0)
+    rspec-core (2.7.1)
+    rspec-expectations (2.7.0)
       diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
+    rspec-mocks (2.7.0)
     thrift (0.6.0)
     tzinfo (0.3.31)
+    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby

--- a/lib/massive_record.rb
+++ b/lib/massive_record.rb
@@ -14,3 +14,7 @@ require 'massive_record/orm/raw_data'
 if defined?(::Rails) && ::Rails::VERSION::MAJOR == 3
   require 'massive_record/rails/railtie'
 end
+
+require 'active_support/core_ext'
+
+ActiveSupport::JSON.backend = :yajl

--- a/lib/massive_record/orm/base.rb
+++ b/lib/massive_record/orm/base.rb
@@ -137,7 +137,7 @@ module MassiveRecord
         private
         
         def class_of_descendant(klass)
-          if klass.superclass.superclass == Base
+          if klass.superclass.superclass == Base || klass.superclass == Base
             klass
           else
             class_of_descendant(klass.superclass)

--- a/lib/massive_record/orm/schema/field.rb
+++ b/lib/massive_record/orm/schema/field.rb
@@ -120,6 +120,10 @@ module MassiveRecord
 
 
         def decode(value)
+          if(value.is_a? Symbol)
+            value = value.to_s
+          end
+
           value = value.force_encoding(Encoding::UTF_8) if utf_8_encoded? && !value.frozen? && value.respond_to?(:force_encoding) 
 
           return value if value.nil? || value_is_already_decoded?(value)

--- a/lib/massive_record/orm/schema/table_interface.rb
+++ b/lib/massive_record/orm/schema/table_interface.rb
@@ -50,7 +50,7 @@ module MassiveRecord
 
             field = Field.new_with_arguments_from_dsl(*field_args)
             column_families.family_by_name_or_new(family_name) << field
-
+            clear_schema_cache
             undefine_attribute_methods if respond_to? :undefine_attribute_methods
 
             field

--- a/lib/massive_record/spec/support/simple_database_cleaner.rb
+++ b/lib/massive_record/spec/support/simple_database_cleaner.rb
@@ -31,6 +31,8 @@ module MassiveRecord
       end
 
       def delete_all_tables
+        notifier = ActiveSupport::Notifications::Fanout.new
+        ActiveSupport::Notifications.notifier = notifier
         tables = MassiveRecord::ORM::Base.connection.tables
         each_orm_class do |klass|
           if tables.include? klass.table.name

--- a/lib/massive_record/version.rb
+++ b/lib/massive_record/version.rb
@@ -1,3 +1,3 @@
 module MassiveRecord
-  VERSION = "0.2.2.rc3"
+  VERSION = "0.2.2.rc4"
 end

--- a/massive_record.gemspec
+++ b/massive_record.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency "thrift", "= 0.6.0"
-  s.add_dependency "activesupport", "~> 3.0.7"
-  s.add_dependency "activemodel", "~> 3.0.7"
+  s.add_dependency "activesupport", "3.1.1"
+  s.add_dependency "activemodel", "3.1.1"
   s.add_dependency "tzinfo"
+  s.add_dependency "yajl-ruby"
 
   s.add_development_dependency "rspec"
 

--- a/spec/orm/cases/attribute_methods_spec.rb
+++ b/spec/orm/cases/attribute_methods_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'orm/models/person'
 
 describe "attribute methods" do
+  include MockMassiveRecordConnection
   include TimeZoneHelper
 
   subject { Person.new "5", :name => "John", :age => "15" }

--- a/spec/orm/cases/base_spec.rb
+++ b/spec/orm/cases/base_spec.rb
@@ -87,7 +87,7 @@ describe MassiveRecord::ORM::Base do
 
     it "should initialize an object via init_with()" do
       model = TestClass.allocate
-      model.init_with 'attributes' => {:foo => 'bar'}
+      model.init_with 'attributes' => {:foo => :bar}
       model.foo.should == 'bar'
     end
 
@@ -115,7 +115,7 @@ describe MassiveRecord::ORM::Base do
 
     it "should stringify keys set on attributes" do
       model = TestClass.allocate
-      model.init_with 'attributes' => {:foo => :bar}
+      model.init_with 'attributes' => {:foo => 'bar'}
       model.attributes.keys.should include("foo")
     end
 

--- a/spec/orm/cases/default_id_spec.rb
+++ b/spec/orm/cases/default_id_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'orm/models/model_without_default_id'
 
 describe ModelWithoutDefaultId do
-  include MockMassiveRecordConnection
-  #include SetUpHbaseConnectionBeforeAll
+  #include MockMassiveRecordConnection
+  include SetUpHbaseConnectionBeforeAll
   #include SetTableNamesToTestTable
 
   context "with auto increment id" do

--- a/spec/orm/cases/persistence_spec.rb
+++ b/spec/orm/cases/persistence_spec.rb
@@ -175,7 +175,7 @@ describe "persistence" do
       describe "create" do
         describe "when table does not exists" do
           before do
-            @new_class = "Person_new_#{ActiveSupport::SecureRandom.hex(5)}"
+            @new_class = "Person_new_#{SecureRandom.hex(5)}"
             @new_class = Object.const_set(@new_class, Class.new(MassiveRecord::ORM::Table))
             
             @new_class.instance_eval do

--- a/spec/orm/cases/table_spec.rb
+++ b/spec/orm/cases/table_spec.rb
@@ -3,6 +3,7 @@ require 'orm/models/person'
 require 'orm/models/test_class'
 
 describe "table classes" do
+  include MockMassiveRecordConnection
   before do
     @subject = MassiveRecord::ORM::Table
     

--- a/spec/orm/persistence/operations/insert_spec.rb
+++ b/spec/orm/persistence/operations/insert_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe MassiveRecord::ORM::Persistence::Operations::Insert do
-  include MockMassiveRecordConnection
+  include SetUpHbaseConnectionBeforeAll
 
   let(:record) { TestClass.new("id-1") }
   let(:options) { {:this => 'hash', :has => 'options'} }

--- a/spec/orm/persistence/operations_spec.rb
+++ b/spec/orm/persistence/operations_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'orm/models/test_class'
 
 describe MassiveRecord::ORM::Persistence::Operations do
+  include SetUpHbaseConnectionBeforeAll
   let(:options) { {:this => 'hash', :has => 'options'} }
 
   describe "factory method" do

--- a/spec/thrift/cases/encoding_spec.rb
+++ b/spec/thrift/cases/encoding_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe "encoding" do
   before :all do
-    @table_name = "encoding_test" + ActiveSupport::SecureRandom.hex(3)
+    @table_name = "encoding_test" + SecureRandom.hex(3)
   end
 
   before do


### PR DESCRIPTION
To get the specs passing within 3.1.1 I needed to added in the yajl engine, and a require to ActiveSupport core extensions to fix issue: https://github.com/CompanyBook/massive_record/issues/42. There was also an issue with the notifier dying in the database cleaner.

The specs are passing with the changes.

Comment:
Fixed the issues with the spec passing for 3.1. Added in yajl to the gemspec. Updated the database cleaner to make sure there is a notifier for the instrumenter when data needs to be cleaned up.
