### PR TITLE
Allow configurable timeouts

### DIFF
--- a/lib/massive_record/adapters/thrift/connection.rb
+++ b/lib/massive_record/adapters/thrift/connection.rb
@@ -8,7 +8,7 @@ module MassiveRecord
         attr_accessor :host, :port, :timeout
     
         def initialize(opts = {})
-          @timeout = 4000
+          @timeout = opts[:timeout] || 4
           @host    = opts[:host]
           @port    = opts[:port] || 9090
           @instrumenter = ActiveSupport::Notifications.instrumenter

--- a/lib/massive_record/wrapper/base.rb
+++ b/lib/massive_record/wrapper/base.rb
@@ -13,7 +13,7 @@ module MassiveRecord
       
       def self.config
         config = YAML.load_file(::Rails.root.join('config', 'hbase.yml'))[::Rails.env]
-        { :host => config['host'], :port => config['port'] }        
+        { :host => config['host'], :port => config['port'], :timeout => config['timeout'] }
       end
 
       def self.connection(opts = {})
@@ -22,6 +22,6 @@ module MassiveRecord
         conn
       end
       
-    end  
+    end
   end
 end

--- a/spec/adapter/thrift/connection_spec.rb
+++ b/spec/adapter/thrift/connection_spec.rb
@@ -10,19 +10,25 @@ describe "A connection" do
     @connection.close if @connection.open?
   end
   
-  it "should have a host and port attributes" do
+  it "should have a host, port, and timeout attributes" do
     connections = [@connection, MassiveRecord::Wrapper::Connection.new(:host => "somewhere")]
     
     connections.each do |conn|
       conn.host.to_s.should_not be_empty
       conn.port.to_s.should_not be_empty
+      conn.timeout.to_s.should_not be_empty
     end
-  end 
+  end
+  
+  it "should allow configurable timeouts" do
+    connection = MassiveRecord::Wrapper::Connection.new(:host => "somewhere", :timeout => 5)
+    connection.timeout.should be 5
+  end
   
   it "should not be open" do
     @connection.open?.should be_false
   end
-   
+  
   it "should not be able to open a new connection with a wrong configuration and Raise an error" do
     @connection.port = 1234
     lambda{@connection.open}.should raise_error(MassiveRecord::Wrapper::Errors::ConnectionException)
@@ -33,7 +39,7 @@ describe "A connection" do
     @connection.open?.should be_true
   end
   
-  it "should not be open if closed" do 
+  it "should not be open if closed" do
     @connection.open.should be_true
     @connection.close.should be_true
     @connection.open?.should be_false


### PR DESCRIPTION
Thrift's timeouts are measured in seconds (`start - Time.now`), having 4000 seconds as the default timeout seems a bit overkill.

This change sets the default timeout to 4 seconds, and allows it to be configured through the YAML file along with the host and port options.
