### PR TITLE
Add support for Scanners with a prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/*
 .DS_Store
 spec/config.yml
 rdoc/
+.project

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,17 +4,17 @@ PATH
     massive_record (0.2.3)
       activemodel (~> 3.0.7)
       activesupport (~> 3.0.7)
-      thrift (= 0.6.0)
+      thrift (~> 0.8.0)
       tzinfo
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.10)
-      activesupport (= 3.0.10)
+    activemodel (3.0.15)
+      activesupport (= 3.0.15)
       builder (~> 2.1.2)
       i18n (~> 0.5.0)
-    activesupport (3.0.10)
+    activesupport (3.0.15)
     builder (2.1.2)
     diff-lcs (1.1.3)
     i18n (0.5.0)
@@ -26,8 +26,8 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    thrift (0.6.0)
-    tzinfo (0.3.31)
+    thrift (0.8.0)
+    tzinfo (0.3.33)
 
 PLATFORMS
   ruby

--- a/lib/massive_record/adapters/thrift/scanner.rb
+++ b/lib/massive_record/adapters/thrift/scanner.rb
@@ -4,7 +4,7 @@ module MassiveRecord
       class Scanner
       
         attr_accessor :connection, :table_name, :column_family_names, :opened_scanner
-        attr_accessor :start_key, :offset_key, :created_at, :limit
+        attr_accessor :start_key, :start_prefix, :offset_key, :created_at, :limit
         attr_accessor :formatted_column_family_names, :column_family_names
       
         def initialize(connection, table_name, column_family_names, opts = {})
@@ -14,6 +14,7 @@ module MassiveRecord
           @column_family_names = opts[:columns] unless opts[:columns].nil?
           @formatted_column_family_names = @column_family_names.collect{|n| "#{n.split(":").first}:"}
           @start_key = opts[:start_key].to_s
+          @start_prefix = opts[:start_prefix].to_s
           @offset_key = opts[:offset_key].to_s
           @created_at = opts[:created_at].to_s
           @limit = opts[:limit] || 10
@@ -24,7 +25,9 @@ module MassiveRecord
         end
       
         def open
-          if created_at.empty?
+          if !start_prefix.empty?
+            self.opened_scanner = connection.scannerOpenWithPrefix(table_name, start_prefix, formatted_column_family_names)
+          elsif created_at.empty?
             self.opened_scanner = connection.scannerOpen(table_name, key, formatted_column_family_names)
           else
             self.opened_scanner = connection.scannerOpenTs(table_name, key, formatted_column_family_names, created_at)

--- a/lib/massive_record/adapters/thrift/table.rb
+++ b/lib/massive_record/adapters/thrift/table.rb
@@ -111,10 +111,12 @@ module MassiveRecord
           opts = self.class.warn_and_change_deprecated_finder_options(opts)
 
           start = opts[:starts_with] && opts[:starts_with].dup.force_encoding(Encoding::BINARY)
+          start_prefix = opts[:start_prefix] && opts[:start_prefix].dup.force_encoding(Encoding::BINARY)
           offset = opts[:offset] && opts[:offset].dup.force_encoding(Encoding::BINARY)
 
           {
             :start_key  => start,
+            :start_prefix  => start_prefix,
             :offset_key => offset,
             :created_at => opts[:created_at],
             :columns    => opts[:select], # list of column families to fetch from hbase

--- a/massive_record.gemspec
+++ b/massive_record.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "massive_record"
 
 
-  s.add_dependency "thrift", "= 0.6.0"
+  s.add_dependency "thrift", "~> 0.8.0"
   s.add_dependency "activesupport", "~> 3.0.7"
   s.add_dependency "activemodel", "~> 3.0.7"
   s.add_dependency "tzinfo"

--- a/spec/adapter/thrift/table_spec.rb
+++ b/spec/adapter/thrift/table_spec.rb
@@ -304,6 +304,14 @@ describe "A table" do
     it "should find 5 rows using the :starts_with option" do
       @table.all(:starts_with => "A").size.should == 5
     end
+    
+    it "should find 1 row using the :start_prefix option" do
+      @table.all(:start_prefix => "A1").size.should == 1
+    end
+  
+    it "should find 5 rows using the :start_prefix option" do
+      @table.all(:start_prefix => "A").size.should == 5
+    end
   
     it "should find 9 rows using the :offset option" do
       @table.all(:offset => "A2").size.should == 9


### PR DESCRIPTION
I have implemented support for prefixed scanners here.
I have also updated the thrift dependency from 0.6.0 to 0.8.0 because of [a bug in 0.6.0](https://issues.apache.org/jira/browse/THRIFT-1400)

I believe that the behavior of the :starts_with key is incorrect.
With HBase when you specify just the start key, the expected behavior is to get every record starting with that key _to the end of the table_ but massive record uses it as a filter for returned rows. Not only is this very inefficient for large rowsets, HBase thrift provides a scanner option for just such a use case: scannerOpenWithPrefix. 
